### PR TITLE
Added V4 parser, base 32 and base -32 decoders, and example encoders

### DIFF
--- a/thinktank/Str2num.md
+++ b/thinktank/Str2num.md
@@ -121,6 +121,10 @@ c=i---i o+=(5*(c>4)+2*(s>s-c)+(t>t-c)+(u>u-c))*b^j++ goto 2
 ### Base 15 positive ints
 *By Azurethi*
 
+
+Decodes non-negative base 15 integers
+
+
 In the interest of sending the most data in the least time, I've tried to crank up the base as much as possible. This will allow larger range for fewer digits, resulting in less processing time.
 
 The code below a modified version of my map from V2 & two test sets based on Zijkhals from V3. This map gives:
@@ -159,6 +163,9 @@ if k==14 then o+="E" goto 2 else o+="!" goto 2 end
 ```
 ### Base 16 positive ints
 _By Azurethi (Reconstructed from **unknown**'s notes)_
+
+Decodes non-negative base 16 integers
+
 A slight modification to the above code, using the two test sets as a binary system (as opposed to the unary style in the base 15 section), allows for correcting up 0, 1, 2 or 3 (previously only 0, 1 or 2). Now that a map with a spacing of 4 can be used:
 
 ```vbnet
@@ -167,6 +174,9 @@ c=i---i o+=(4*((c>3)+(c>7)+(c>b))+(x>x-c)+2*(y>y-c))*16^j++ goto 2
 ```
 ### Base 32 positive ints
 *By Zijkhal*
+
+
+Decodes non-negative base 32 integers
 
 This version makes heavy use of the **s** test, and maximizes use out of each test by making each consecutive test adjust the guess by twice as much as the previous one.
 

--- a/thinktank/Str2num.md
+++ b/thinktank/Str2num.md
@@ -201,7 +201,7 @@ o-- o-- if d==26 then o+="Q" end if d==27 then o+="R" end goto 2
 o-- o-- if d==28 then o+="S" end if d==29 then o+="T" end goto 2
 o-- o-- if d==30 then o+="U" end if d==31 then o+="V" end goto 2
 ```
-**speed vs base 10**
+**speed vs base 10**\
 Decoding a base 32 number is on average roughly 50% faster than decoding a base 10 number.
 Encoding, however is instant for base 10 numbers because of the automatic type conversion from number to string yolol provides (string = number + ""), while the base 32 encoder takes up to 2 ticks per base 32 digits.
 The entire num -> str -> num path is roughly half as fast as base 10.

--- a/thinktank/Str2num.md
+++ b/thinktank/Str2num.md
@@ -294,7 +294,7 @@ Optimising the "Any +ve" version slightly allowed space for the new main attract
 In the event you wish to add custom features, it may help to have more space on the last line, with this in mind we have also optimised for the fewest characters possible (above is fewest variables used) by switching to the V4 parser & carrying the (c<0) check across both lines. The V4 parser also parses "-" as 0 so no additional correction is needed when negating n.
 
 ```vbnet
-i="14975" s="98743" t="98642" u="94321" b=10 o=0
+i="-64.12" s="98743" t="98642" u="94321" b=10 n=0 j=0
 c=i---i n+=(5*(c>4)+2*(s>s-c)+(t>t-c)+(u>u-c))*b^j++ a=c<0 goto 2+a
 o=n*(1-2*a) n/=b^--j j=0 goto 2+2*(i=="")
 ```

--- a/thinktank/Str2num.md
+++ b/thinktank/Str2num.md
@@ -185,7 +185,7 @@ Another trick is that this requires the numbers to be decoded backwards, which s
 ```vbnet
 s="VTRPNLJHFDB97531" t="VURQNMJIFEBA7632" u="VUTSNMLKFEDC7654"
 v="VUTSRQPOFEDCBA98" o=0 i="0IO3"
-c=i---i o=o*32+16*(c>"f")+(s>s-c)+2*(t>t-c)+4*(u>u-c)+8*(v>v-c) goto 3
+c=i---i o=o*32+16*(c>"F")+(s>s-c)+2*(t>t-c)+4*(u>u-c)+8*(v>v-c) goto 3
 ```
 This will output o=123456, if i input string is left as is
 
@@ -228,7 +228,7 @@ The decoder is the same as the base 32 decoder, but the number base is changed f
 ```vbnet
 s="VTRPNLJHFDB97531" t="VURQNMJIFEBA7632" u="VUTSNMLKFEDC7654"
 v="VUTSRQPOFEDCBA98" o=0 i="89s3" b=-32
-c=i---i o=o*b+16*(c>"f")+(s>s-c)+2*(d>d-c)+4*(f>f-c)+8*(g>g-c) goto 3
+c=i---i o=o*b+16*(c>"F")+(s>s-c)+2*(d>d-c)+4*(f>f-c)+8*(g>g-c) goto 3
 ```
 This will output o=-69912, if i input is left as is
 

--- a/thinktank/Str2num.md
+++ b/thinktank/Str2num.md
@@ -12,7 +12,7 @@ Converting YOLOL Strings to numbers as fast as possible! (Let me know if I'm wro
   - [Base 10 positive ints](#Base-10-positive-ints)
     - [Version 1](#Version-1)
     - [Version 2 **(Variable Optimised)**](#Version-2)
-    - [Version 3](#Version-3)
+    - [Version 3 **(Balanced)**](#Version-3)
     - [Version 4 **(Character Optimised)**](#Version-4)
   - [Base 15 positive ints](#Base-15-positive-ints)
   - [Base 16 positive ints](#Base-16-positive-ints)
@@ -291,10 +291,10 @@ o=n*(1-2*(c<0))-(c<0)*10^--j n=1+n/10^j j=0 goto 2+2*(i=="")
 ```
 Optimising the "Any +ve" version slightly allowed space for the new main attraction in line 2 ``o=n*(1-2*(c<0))-(c<0)*10^--j``. This negates the number when the last char is "ascii<0" (with apropriate correction for the parser parsing "-" as a digit = -1)
 
-In the event you wish to add custom features, it may help to have more space on the last line, with this in mind we have also optimised for the fewest characters possible (above is fewest variables used) by switching to the V3 parser & carrying the (c<0) check across both lines. The V3 parser also parses "-" as 0 so no additional correction is needed when negating n.
+In the event you wish to add custom features, it may help to have more space on the last line, with this in mind we have also optimised for the fewest characters possible (above is fewest variables used) by switching to the V4 parser & carrying the (c<0) check across both lines. The V4 parser also parses "-" as 0 so no additional correction is needed when negating n.
 
 ```vbnet
-i="12.34" o=0 j=0 b=10 s="97531"
-c=i---i n+=(2*((c>1)+(c>3)+(c>5)+(c>7))+(s>s-c))*b^j++ a=c<0 goto 2+a
+i="14975" s="98743" t="98642" u="94321" b=10 o=0
+c=i---i n+=(5*(c>4)+2*(s>s-c)+(t>t-c)+(u>u-c))*b^j++ a=c<0 goto 2+a
 o=n*(1-2*a) n/=b^--j j=0 goto 2+2*(i=="")
 ```


### PR DESCRIPTION
 - Added V4 parser, two characters shorter than V3, but uses two extra variables, V3 Parser marked as "balanced"
 - Added base 32 decoder and encoder
 - Added base -32 decoder and encoder
 - Updated character optimized Universal parser to use the V4 parser
 - Fixed mapping in description of V1 parser
 - Changed parser titles from "base X ints" to base X positive ints" with a short description below title to better reflect their capabilities